### PR TITLE
use analytic derivs for helm + finish test

### DIFF
--- a/src/helmholtz.H
+++ b/src/helmholtz.H
@@ -35,18 +35,7 @@ inline auto get_helmholtz_terms(T rho, T temp, T Ye)
     helm.d3F_drho2dT = (state.d2p_drhodT - 2.0_rt * rho_inv * state.dp_dT) * rho_inv * rho_inv;
     helm.d3F_drhodT2 = -state.d2s_drhodT;
 
-    // for the 4th derivative term, we need to do a differencing
-    // we'll do ∂/∂ρ(∂³F/∂ρ∂T²)
-    const real_t eps{0.01_rt};
-    auto drho{eps * rho};
-    auto [deriv, _err] = fd::adaptive_diff<real_t>([&] (real_t _rho) -> real_t
-       {
-           auto es_eps = eos.pe_state(_rho, temp, Ye);
-           // construct ∂³F/∂ρ∂T²
-           return -es_eps.d2s_drhodT;
-       }, rho, drho);
-
-    helm.d4F_drho2dT2 = deriv;
+    helm.d4F_drho2dT2 = -state.d3s_drho2dT;
 
     return {helm, state};
 

--- a/tests/test_helmholtz.cpp
+++ b/tests/test_helmholtz.cpp
@@ -18,7 +18,6 @@ void
 test_helm_rho_derivs() {
 
     const real_t Ye{0.5_rt};
-
     const real_t eps{0.01_rt};
 
     std::println("");
@@ -51,7 +50,6 @@ void
 test_helm_T_derivs() {
 
     const real_t Ye{0.5_rt};
-
     const real_t eps{0.01_rt};
 
     std::println("");
@@ -84,7 +82,6 @@ void
 test_helm_rho2_derivs() {
 
     const real_t Ye{0.5_rt};
-
     const real_t eps{0.01_rt};
 
     std::println("");
@@ -116,7 +113,6 @@ void
 test_helm_T2_derivs() {
 
     const real_t Ye{0.5_rt};
-
     const real_t eps{0.01_rt};
 
     std::println("");
@@ -142,13 +138,12 @@ test_helm_T2_derivs() {
 }
 
 
-// ∂²p/∂ρ∂T
+// ∂²F/∂ρ∂T
 
 void
 test_helm_rhoT_derivs() {
 
     const real_t Ye{0.5_rt};
-
     const real_t eps{0.01_rt};
 
     std::println("");
@@ -180,7 +175,6 @@ void
 test_helm_rhoT2_derivs() {
 
     const real_t Ye{0.5_rt};
-
     const real_t eps{0.01_rt};
 
     std::println("");
@@ -206,13 +200,12 @@ test_helm_rhoT2_derivs() {
 }
 
 
-// ∂³F/∂ρ²∂T²
+// ∂³F/∂ρ²∂T
 
 void
 test_helm_rho2T_derivs() {
 
     const real_t Ye{0.5_rt};
-
     const real_t eps{0.01_rt};
 
     std::println("");
@@ -238,6 +231,37 @@ test_helm_rho2T_derivs() {
 }
 
 
+// ∂⁴F/∂ρ²∂T²
+
+void
+test_helm_rho2T2_derivs() {
+
+    const real_t Ye{0.5_rt};
+    const real_t eps{0.01_rt};
+
+    std::println("");
+    util::green_println("testing ∂⁴F/∂ρ²∂T² via differencing");
+
+    for (auto T : Ts) {
+        for (auto rho : rhos) {
+            auto [helm, eos] = get_helmholtz_terms(rho, T, Ye);
+
+            auto dT{eps * T};
+            auto [deriv, _err] = fd::adaptive_diff2<real_t>([&] (real_t T_) -> real_t
+                {
+                    auto [helm_eps, eos_eps] = get_helmholtz_terms(rho, T_, Ye);
+                    return helm_eps.d2F_drho2;
+                }, T, dT);
+
+            real_t err = mp::abs(helm.d4F_drho2dT2 - deriv) / mp::abs(helm.d4F_drho2dT2);
+            util::threshold_println(err,
+                                    "ρ = {:8.3g} T = {:8.3g},  ∂⁴F/∂ρ²∂T² = {:15.8g},  error = {:11.5g}",
+                                    rho, T, helm.d4F_drho2dT2, err);
+        }
+    }
+}
+
+
 
 auto main() -> int
 {
@@ -251,5 +275,7 @@ auto main() -> int
 
     test_helm_rhoT2_derivs();
     test_helm_rho2T_derivs();
+
+    test_helm_rho2T2_derivs();
 
 }


### PR DESCRIPTION
We no longer use differencing to compute any of the derivatives needed for the Helmholtz table interpolation,
instead all 9 coefficients are computed using direct integration + algebraic combinations.

This also updates the test_helmholtz test to check all terms via differencing.